### PR TITLE
rebranded site from ITS Public Data Hub to ITS DataHub

### DIFF
--- a/element1/index.html
+++ b/element1/index.html
@@ -2,7 +2,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta http-equiv="x-ua-compatible" content="IE=edge">
-  <title>ITS Public Data Hub Visualization Element 1: Integration</title>
+  <title>ITS DataHub Visualization Element 1: Integration</title>
   <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon">
   <link rel="icon" href="../img/font-awesome/favicons/favicon.ico" type="image/x-icon">
 
@@ -31,7 +31,7 @@
       <a class="menu-btn" href="#">Menu</a>
       <div class="site-logo" id="logo">
         <em>
-          <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS Public Data Hub: Visualization</a>
+          <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS DataHub: Visualization</a>
         </em>
         </div>
       </div>
@@ -107,7 +107,7 @@
 
     <!-- Banner section -->
     <header>
-      <p class="site-subheading">ITS PUBLIC DATA HUB VISUALIZATION</p>
+      <p class="site-subheading">ITS DATAHUB VISUALIZATION</p>
       <h1 id="getting-started">Characteristics of Transportation Systems</h1>
     </header>
       <p class="usa-font-lead">The Pasadena Data Environment consists primarily of network and network

--- a/element2/index.html
+++ b/element2/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta http-equiv="x-ua-compatible" content="IE=edge">
-  <title>ITS Public Data Hub Visualization Element 2: Communication</title>
+  <title>ITS DataHub Visualization Element 2: Communication</title>
   <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon">
   <link rel="icon" href="../img/font-awesome/favicons/favicon.ico" type="image/x-icon">
 
@@ -33,7 +33,7 @@
       <a class="menu-btn" href="#">Menu</a>
       <div class="site-logo" id="logo">
         <em>
-          <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS Public Data Hub: Visualization</a>
+          <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS DataHub: Visualization</a>
         </em>
         </div>
       </div>
@@ -109,7 +109,7 @@
 
     <!-- Banner section -->
     <header>
-      <p class="site-subheading">ITS PUBLIC DATA HUB VISUALIZATION</p>
+      <p class="site-subheading">ITS DATAHUB VISUALIZATION</p>
       <h1 id="getting-started">Impact of Communication</h1>
     </header>
     <p class="usa-font-lead">The Connected Vehicle Safety Pilot Program is a research initiative that features real-world

--- a/element3/index.html
+++ b/element3/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta http-equiv="x-ua-compatible" content="IE=edge">
-  <title>ITS Public Data Hub Visualization Element 3: Weather</title>
+  <title>ITS DataHub Visualization Element 3: Weather</title>
   <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon">
   <link rel="icon" href="../img/font-awesome/favicons/favicon.ico" type="image/x-icon">
 
@@ -165,7 +165,7 @@
       <a class="menu-btn" href="#">Menu</a>
       <div class="site-logo" id="logo">
         <em>
-          <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS Public Data Hub: Visualization</a>
+          <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS DataHub: Visualization</a>
         </em>
         </div>
       </div>
@@ -241,7 +241,7 @@
 
     <!-- Banner section -->
     <header>
-      <p class="site-subheading">ITS PUBLIC DATA HUB VISUALIZATION</p>
+      <p class="site-subheading">ITS DATAHUB VISUALIZATION</p>
       <h1 id="getting-started">Impact of Weather</h1>
     </header>
       <p class="usa-font-lead">Integrated Mobile Observations (IMO) is a data set that includes weather and vehicle information
@@ -271,7 +271,7 @@
 
     <h3>Methodology</h3>
     <p>The visualization uses <a href="https://data.transportation.gov/dataset/Minnesota-DOT-Mobile-Observation-Data/wjsz-qgmw">Minnesota DOT Mobile
-       Observation data on the ITS Public Data Hub</a> as well as the Minnesota Environmental Sensor Station
+       Observation data on the ITS DataHub</a> as well as the Minnesota Environmental Sensor Station
        data on the <a href="https://wxde.fhwa.dot.gov/">Weather Data Environment</a>.  The timeframe between February 19 2014
        through February 22 2014 was selected because of a snowstorm that passed over Minnesota during this time.  Data sets were
        loaded into a database and then exported to a csv file with the columns that were relevant to the 

--- a/element4/index.html
+++ b/element4/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta http-equiv="x-ua-compatible" content="IE=edge">
-  <title>ITS Public Data Hub Visualization Element 4: Traffic Interventions</title>
+  <title>ITS DataHub Visualization Element 4: Traffic Interventions</title>
   <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon">
   <link rel="icon" href="../img/font-awesome/favicons/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="../css/styleguide.css">
@@ -28,7 +28,7 @@
       <a class="menu-btn" href="#">Menu</a>
       <div class="site-logo" id="logo">
         <em>
-          <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS Public Data Hub: Visualization</a>
+          <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS DataHub: Visualization</a>
           </em>
         </div>
       </div>
@@ -98,7 +98,7 @@
       <div class="styleguide-content usa-content">
 
         <header>
-          <p class="site-subheading">ITS PUBLIC DATA HUB VISUALIZATION</p>
+          <p class="site-subheading">ITS DATAHUB VISUALIZATION</p>
           <h1 id="getting-started">Impact of Interventions</h1>
         </header>
 
@@ -242,7 +242,7 @@
 
         <!-- METHODOLOGY SECTION -->
         <h3>Methodology</h3>
-        <p>These visualizations use the <a href="https://data.transportation.gov/browse?q=mmitss&sortBy=relevance">MMITSS data on the ITS Public Data Hub</a>.  We used the GPS and BSM data to get positions of all instrumented vehicles, filtered out all positions greater than 50 meters from the center of the Daisy Mountain Dr/Gavilan Peak Pkwy intersection, and additionally filtered out all positions where the vehicle's speed was greater than 5 km/h.  After downsampling from 10Hz to 1Hz, we counted the number of points in each time interval to yield the total vehicle-seconds of delay in the time interval.</p>
+        <p>These visualizations use the <a href="https://data.transportation.gov/browse?q=mmitss&sortBy=relevance">MMITSS data on the ITS DataHub</a>.  We used the GPS and BSM data to get positions of all instrumented vehicles, filtered out all positions greater than 50 meters from the center of the Daisy Mountain Dr/Gavilan Peak Pkwy intersection, and additionally filtered out all positions where the vehicle's speed was greater than 5 km/h.  After downsampling from 10Hz to 1Hz, we counted the number of points in each time interval to yield the total vehicle-seconds of delay in the time interval.</p>
         <p>For a more formal assessment of the impact of MMITSS, see the <a href="http://ntl.bts.gov/lib/55000/55700/55710/MMITSS_IA_REPORT_0811_v1.4.pdf">MMITSS Impact Assessment</a> (<a href="https://get.adobe.com/reader/">Get Acrobat Reader</a>).</p>
         <p>The visualizations were created with the <a href="https://d3js.org/">D3.js</a> JavaScript charting library by <a href="https://bost.ocks.org/mike/">Mike Bostock</a>.</p>
 

--- a/element6/index.html
+++ b/element6/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8">
         <meta http-equiv="x-ua-compatible" content="IE=edge">
-        <title>ITS Public Data Hub Visualization Element 5: Depth of Connected Vehicle Data</title>
+        <title>ITS DataHub Visualization Element 5: Depth of Connected Vehicle Data</title>
         <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon">
         <link rel="icon" href="../img/font-awesome/favicons/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="../css/styleguide.css">
@@ -26,7 +26,7 @@
                 <a class="menu-btn" href="#">Menu</a>
                 <div class="site-logo" id="logo">
                     <em>
-                    <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS Public Data Hub: Visualization</a>
+                    <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS DataHub: Visualization</a>
                     </em>
                 </div>
             </div>
@@ -109,7 +109,7 @@
             <div class="styleguide-content usa-content">
 
                 <header>
-                    <p class="site-subheading">ITS PUBLIC DATA HUB VISUALIZATION</p>
+                    <p class="site-subheading">ITS DATAHUB VISUALIZATION</p>
                     <h1 id="getting-started">Breadth of Basic Safety Message Data</h1>
                 </header>
                 <p class="usa-font-lead">Vehicles equipped to record Basic Safety Message (BSM) data collect vast amounts of data across a wide number of variables. This visualization element presents an overview of those variables. For each file, representative samples of varying durations display data associated with a vehicle, conveying the breadth of data in the BSM protocol. </p>
@@ -646,7 +646,7 @@
                 <!-- END OF VISUALIZATION ELEMENT -->
                 <!-- METHODOLOGY SECTION -->
                 <h3>Methodology</h3>
-                <p>There is an enormous amount of BSM data available in the <a href="https://data.transportation.gov/Automobiles/Safety-Pilot-Model-Deployment-Data/a7qq-9vfe">Safety Pilot Model Deployment Data environment</a> on the ITS Public Data Hub. This visualization looks at a small slice of that data as a way to convey the breadth of the data without requiring users to download large files. The visualization was created with the <a href="https://d3js.org/">D3.js</a> data visualization library, created by <a href="https://bost.ocks.org/mike/">Mike Bostock</a>.</p>
+                <p>There is an enormous amount of BSM data available in the <a href="https://data.transportation.gov/Automobiles/Safety-Pilot-Model-Deployment-Data/a7qq-9vfe">Safety Pilot Model Deployment Data environment</a> on the ITS DataHub. This visualization looks at a small slice of that data as a way to convey the breadth of the data without requiring users to download large files. The visualization was created with the <a href="https://d3js.org/">D3.js</a> data visualization library, created by <a href="https://bost.ocks.org/mike/">Mike Bostock</a>.</p>
                 <!-- DOWNLOAD INSTRUCTIONS -->
                 <h3>Download Instructions</h3>
                 <p>You can download the code used for this visualization element from <a href="https://github.com/FHWA/RDE-Visualization-Website">the FHWA Github site</a>.</p>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8">
   <meta http-equiv="x-ua-compatible" content="IE=edge">
-  <title>ITS Public Data Hub Visualization Examples</title>
+  <title>ITS DataHub Visualization Examples</title>
   <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
   <link rel="icon" href="img/font-awesome/favicons/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="css/styleguide.css">
@@ -22,7 +22,7 @@
       <a class="menu-btn" href="#">Menu</a>
       <div class="site-logo" id="logo">
         <em>
-          <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS Public Data Hub: Visualization</a>
+          <a href="/data/visualizations" accesskey="1" title="Home" aria-label="Home">ITS DataHub: Visualization</a>
         </em>
       </div>
     </div>
@@ -99,11 +99,11 @@
 
     <!-- Banner section -->
     <header>
-      <p class="site-subheading">ITS PUBLIC DATA HUB VISUALIZATION</p>
-      <h1 id="getting-started">Visualizing the ITS Public Data Hub</h1>
+      <p class="site-subheading">ITS DATAHUB VISUALIZATION</p>
+      <h1 id="getting-started">Visualizing the ITS DataHub</h1>
     </header>
 
-      <p class="usa-font-lead">The US Federal Highway Administration's ITS Public Data Hub contains a vast amount of collected, measured, and simulated data about the highway systems of the United States. This website contains six prototype visualization elements that explore the depth and breadth of the data in the ITS Public Data Hub.</p>
+      <p class="usa-font-lead">The US Federal Highway Administration's ITS DataHub contains a vast amount of collected, measured, and simulated data about the highway systems of the United States. This website contains six prototype visualization elements that explore the depth and breadth of the data in the ITS DataHub.</p>
 
 
       <div class="usa-width-one-whole usa-alert usa-alert-info">
@@ -121,7 +121,7 @@
       </h3>
 
       <h4>Element 1: Integration</h4>
-      <p>The Pasadena data environment in the ITS Public Data Hub contains road-link level simulated traffic data for a period of several months in 2011. The visualization shows simulated traffic for the 24-hour period of October 1st, 2011, around a busy part of town. </p>
+      <p>The Pasadena data environment in the ITS DataHub contains road-link level simulated traffic data for a period of several months in 2011. The visualization shows simulated traffic for the 24-hour period of October 1st, 2011, around a busy part of town. </p>
       <img src="img/el1example.jpg" alt="Image of element 1" />
       <p>Element 1 requires a web browser that renders WebGL. If you are unable to interact with the visualization, you can view a video of it in action <a href="https://vimeo.com/184231709">at this link</a>.</p>
       <p><a href="element1/" class="usa-button-outline" type="usa/button">Click Here to View Element 1</a></p>
@@ -134,7 +134,7 @@
 
 
       <h4>Element 3: Weather</h4>
-      <p>The Federal Highway Administration also maintains the <a href="https://wxde.fhwa.dot.gov/">Weather Data Environment</a>, known as the WxDE, which is a repository of traffic-related weather data that can be used in research. Visualization element 3 combines data from the WxDE with data from the Minnesota DOT Mobile Observation data environment, on the ITS Public Data Hub, to show weather, movement of snowplows, and road conditions during a blizzard in February of 2014.</p>
+      <p>The Federal Highway Administration also maintains the <a href="https://wxde.fhwa.dot.gov/">Weather Data Environment</a>, known as the WxDE, which is a repository of traffic-related weather data that can be used in research. Visualization element 3 combines data from the WxDE with data from the Minnesota DOT Mobile Observation data environment, on the ITS DataHub, to show weather, movement of snowplows, and road conditions during a blizzard in February of 2014.</p>
       <img src="img/el3example.jpg" alt="Image of element 3" />
       <p>Element 3 requires a web browser that renders WebGL. If you are unable to interact with the visualization, you can view a video of it in action <a href="https://vimeo.com/184229812">at this link</a>.</p>
       <p><a href="element3/" class="usa-button-outline" type="usa/button">Click Here to View Element 3</a></p>
@@ -147,7 +147,7 @@
 
 
       <h4>Element 5: Depth of Connected Vehicle Data</h4>
-      <p>While visualization element 5 presents the depth of data available in the ITS Public Data Hub, Element 5 presents a view into the breadth of data that is available in one of the many ITS Public Data Hub data environments. Element 5 is an interactive visual overview of the Basic Safety Message data set in the Safety Pilot Model Deployment data enviroment that logs vehicles' attempts to communicate with roadside equipment, as also shown in Element 2.</p>
+      <p>While visualization element 5 presents the depth of data available in the ITS DataHub, Element 5 presents a view into the breadth of data that is available in one of the many ITS DataHub data environments. Element 5 is an interactive visual overview of the Basic Safety Message data set in the Safety Pilot Model Deployment data enviroment that logs vehicles' attempts to communicate with roadside equipment, as also shown in Element 2.</p>
       <img src="img/el6example.png" alt="Image of element 5" />
       <p><a href="element6/" class="usa-button-outline" type="usa/button">Click Here to View Element 5</a></p>
 


### PR DESCRIPTION
Removed all references to public data. Updated link to pdf on about page. 